### PR TITLE
Add TIMG.yaml for Timora Garden jetton

### DIFF
--- a/jettons/TIMG.yaml
+++ b/jettons/TIMG.yaml
@@ -1,0 +1,12 @@
+- name: Timora Garden
+  symbol: TIMG
+  description: Timora is a blockchain ecosystem that empowers users to securely preserve, share, and own their digital memories in a decentralized environment. The native token, TIMG, incentivizes user engagement while enabling access to premium features, community participation, and contributions to sustainability initiatives. 
+  address: EQCAFupS6_J49ORqoeY3k08lTvLQlDgi9ayk4UNYTBtT_TJF
+  image: "https://gray-casual-cicada-934.mypinata.cloud/ipfs/bafkreif4ksjfgg2rnbjlqooqiwv4qqycfqohsmlepvm4ardecfsnwbw6re"
+  websites:
+    - "https://timorai.com/"
+  social:
+    - "https://t.me/info_timoragarden"
+    - "https://x.com/timoragarden"
+
+


### PR DESCRIPTION
This PR adds the Timora Garden (TIMG) token to the jettons directory. The details of the token are as follows:

- **Name:** Timora Garden
- **Symbol:** TIMG
- **Description:** Timora is a blockchain ecosystem that empowers users to securely preserve, share, and own their digital memories in a decentralized environment. The native token, TIMG, incentivizes user engagement while enabling access to premium features, community participation, and contributions to sustainability initiatives.
- **Contract Address:** EQCAFupS6_J49ORqoeY3k08lTvLQlDgi9ayk4UNYTBtT_TJF
- **Image:** Hosted on IPFS: https://gray-casual-cicada-934.mypinata.cloud/ipfs/bafkreif4ksjfgg2rnbjlqooqiwv4qqycfqohsmlepvm4ardecfsnwbw6re
- **Website:** [https://timorai.com/](https://timorai.com/)
- **Social Links:**
  - [Telegram](https://t.me/info_timoragarden)
  - [X (Twitter)](https://x.com/timoragarden)

Please note:
- The token logo is hosted on IPFS and does not use a `ton.api` link as per the guidelines.
- The `.yaml` file has been added to the `jettons/` directory without modifying any auto-generated `.json` files.

Thank you for reviewing this PR.
